### PR TITLE
fix a critical bug in the set_box_info method of BoxMap

### DIFF
--- a/test/BoxMap_Test.cpp
+++ b/test/BoxMap_Test.cpp
@@ -8,7 +8,7 @@
 // @section LICENSE
 // License: newBSD
 //
-// Copyright © 2016, HU University of Applied Sciences Utrecht.
+// Copyright ï¿½ 2016, HU University of Applied Sciences Utrecht.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -204,32 +204,41 @@ TEST(BoxMap, BoundingBox){
         );
 }
 
+// defines the size of the grid of squares that will be inserted in the stress test
+#define MAP_TEST_SIZE 150
+
 /*
 * Real world test / stress test
 */
 TEST(BoxMap, UsageExample){
-    std::uniform_real_distribution<double> random_real(-100.0, 100.0);
-    std::default_random_engine re(time(NULL));
-    srand(time(NULL));
+//    std::uniform_real_distribution<double> random_real(-100.0, 100.0);
+//    std::default_random_engine re(time(NULL));
+//    srand(time(NULL));
     r2d2::BoxMap bm{};
     cout << "May take a minute or 2...\n";
 
-    for (int i = 0; i < 20; i++){
-        bm.set_box_info(
-            r2d2::Box{
-            r2d2::Coordinate{
-                random_real(re)*r2d2::Length::METER,
-                random_real(re)*r2d2::Length::METER,
-                random_real(re)*r2d2::Length::METER
-            },
-            r2d2::Coordinate{
-                    random_real(re)*r2d2::Length::METER,
-                    random_real(re)*r2d2::Length::METER,
-                    random_real(re)*r2d2::Length::METER
-                }
-        },
-        r2d2::BoxInfo{ rand() % 2 == 0, rand() % 2 == 0, rand() % 2 == 0 }
-        );
+    for (int x = -MAP_TEST_SIZE; x < MAP_TEST_SIZE; ++x) {
+        for (int y = -MAP_TEST_SIZE; y < MAP_TEST_SIZE; ++y) {
+            r2d2::Coordinate new_pos{
+                    x*r2d2::Length::METER,
+                    y*r2d2::Length::METER,
+                    -1*r2d2::Length::METER
+            };
+
+            bm.set_box_info(
+                    r2d2::Box{
+                            new_pos,
+                            new_pos
+                            + r2d2::Translation{
+                                    2*r2d2::Length::METER,
+                                    2*r2d2::Length::METER,
+                                    2*r2d2::Length::METER
+                            }
+                    },
+                    r2d2::BoxInfo{ rand() % 2 == 0, rand() % 2 == 0, rand() % 2 == 0 }
+            );
+
+        }
     }
     ASSERT_GT(bm.get_map_size(), 9);
     ASSERT_TRUE(


### PR DESCRIPTION
This fix takes the time complexity of the algorithm down to O(n^2) from an estimated O(2^n).
Also did a lot op optimisations to the code, increasing performance by a large margin.
Some benchmarks follow:
- In both the optimised and unoptimised versions
  of the code the fix has been applied.
- All test were done on an AMD FX-6350 @ 4.5Ghz,
  with the same test case for both versions.
- The code was built using the supplied cmake build,
  using the release build configuration.

| Test size | total insertions | unoptimised | optimised |
| --- | --- | --- | --- |
| 50 | 10000 | 1610+-100ms | 195+-10ms |
| 100 | 40000 | 33.2+-.1s | 3.21+-.5s |
| 150 | 90000 | 199+-3s | 19.3+-.1s |

From these tests it can be concluded that:
1. There is an average speedup of around 860%.
2. The algorithm conforms reasonably well to the calculated O(n^2) complexity.
